### PR TITLE
added fifth set of tests

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/IfSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/IfSqlNode.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/ProjectFifthTests.java
+++ b/src/test/java/org/apache/ibatis/ProjectFifthTests.java
@@ -1,0 +1,54 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.ibatis.binding.BindingException;
+import org.junit.jupiter.api.Test;
+
+class ProjectFifthTests {
+
+  @Test
+  void executeUpdate_ReturnsRowCount_WhenRowCountIsNonNegative() {
+    // Arrange
+    int rowCount = 3;
+
+    // Act
+    int result = handleExecuteUpdateResult(rowCount);
+
+    // Assert
+    assertEquals(3, result);
+  }
+
+  @Test
+  void executeUpdate_ThrowsBindingException_WhenRowCountIsNegative() {
+    // Arrange
+    int rowCount = -1;
+
+    // Act & Assert
+    assertThrows(BindingException.class, () -> handleExecuteUpdateResult(rowCount));
+  }
+
+  // Simulated private method for handling update results
+  private int handleExecuteUpdateResult(int rowCount) {
+    if (rowCount < 0) {
+      throw new BindingException("Invalid update count: " + rowCount);
+    }
+    return rowCount;
+  }
+}

--- a/src/test/java/org/apache/ibatis/ProjectFourthTests.java
+++ b/src/test/java/org/apache/ibatis/ProjectFourthTests.java
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.ibatis.session.RowBounds;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/apache/ibatis/submitted/optional_on_mapper_method/OptionalOnMapperMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/optional_on_mapper_method/OptionalOnMapperMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I was able to add the fifth set of tests that focused on using equivalence partitioning to split up the tests into partitions. Passing (non-negative numbers), and failure(negative numbers). 
![image](https://github.com/user-attachments/assets/7eee4966-da88-4d9c-8323-dd5c3b415590)
